### PR TITLE
Upgrade HiGlass unpkg urls to 1.8.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Cistrome / HiGlass</title>
-  <link rel="stylesheet" href="https://unpkg.com/higlass@1.5.6/dist/hglib.css" type="text/css">
+  <link rel="stylesheet" href="https://unpkg.com/higlass@1.8.0/dist/hglib.css" type="text/css">
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" type="text/css">
 
   <style type="text/css">
@@ -102,7 +102,7 @@
 
 <script src="https://unpkg.com/higlass-multivec@0.2.0/dist/higlass-multivec.js"></script>
 <script src="https://unpkg.com/higlass-time-interval-track@0.1.8/dist/higlass-time-interval-track.js"></script>
-<script src="https://unpkg.com/higlass@1.5.5/dist/hglib.js"></script>
+<script src="https://unpkg.com/higlass@1.8.0/dist/hglib.js"></script>
 
 <script>
 


### PR DESCRIPTION
Fixes tooltip position bug by upgrading to newer version of HiGlass